### PR TITLE
[Fix/#45]: axios instance 통일, 비밀번호 변경 api 요청 수정

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,8 +1,8 @@
-import { baseInstance } from './instance';
+import { httpClient } from '@/api/http';
 
 export const requestCode = async (contact: string) => {
   try {
-    const result = await baseInstance.post('/users/auth/otp', { contact });
+    const result = await httpClient.post('/users/auth/otp', { contact });
     return result;
   } catch (err) {
     window.alert('오류가 발생했습니다. 다시 시도해주세요.');
@@ -11,7 +11,7 @@ export const requestCode = async (contact: string) => {
 
 export const verifyCode = async (contact: string, code: number) => {
   try {
-    await baseInstance.post('/users/auth/otp/validation', {
+    await httpClient.post('/users/auth/otp/validation', {
       contact,
       otp: +code,
     });

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,0 +1,65 @@
+import { BASE_URL, DEFAULT_TIMOUT } from '@/constants/api';
+import { STORAGE_KEY } from '@/constants/storage';
+import useSessionStore from '@/store/sessionStore';
+import { deleteTokenFromStorage, getTokenFromStorage } from '@/utils/storage';
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+const createClient = (config?: AxiosRequestConfig): AxiosInstance => {
+  const axiosInstance = axios.create({
+    baseURL: BASE_URL,
+    timeout: DEFAULT_TIMOUT,
+    withCredentials: true,
+    ...config,
+  });
+
+  axiosInstance.interceptors.request.use(
+    (req) => {
+      const { accessToken } = getTokenFromStorage();
+      if (accessToken) {
+        req.headers.Authorization = accessToken;
+      }
+      return req;
+    },
+    (err) => Promise.reject(err)
+  );
+
+  axiosInstance.interceptors.response.use(
+    (res) => {
+      return res;
+    },
+    async (err) => {
+      const { isLoggedIn, setIsLoggedIn } = useSessionStore.getState();
+      const { refreshToken } = getTokenFromStorage();
+
+      if (isLoggedIn && err.response.status === 401) {
+        const originRequest = err.config;
+        try {
+          const result = await axios.post(`${BASE_URL}/users/refresh`, {
+            headers: {
+              refresh: refreshToken,
+            },
+          });
+
+          const newAccessToken = result.data.accessToken;
+
+          if (newAccessToken) {
+            sessionStorage.setItem(STORAGE_KEY.accessToken, newAccessToken);
+            originRequest.headers.Authorization = newAccessToken;
+          }
+          return axiosInstance(originRequest);
+        } catch (error) {
+          setIsLoggedIn(false);
+          deleteTokenFromStorage();
+          window.alert('로그인 세션이 만료되었습니다. 다시 로그인해주세요.');
+          window.location.href = '/auth/login';
+          return Promise.reject(error);
+        }
+      }
+      return Promise.reject(err);
+    }
+  );
+
+  return axiosInstance;
+};
+
+export const httpClient = createClient();

--- a/src/features/CatalogDetail/api/liquor.api.ts
+++ b/src/features/CatalogDetail/api/liquor.api.ts
@@ -1,8 +1,8 @@
-import { authInstance } from '@/api/instance';
+import { httpClient } from '@/api/http';
 
 export const getLiquorDetail = async (liquorId: number) => {
   try {
-    const result = await authInstance.get(`/liquors/${liquorId}`);
+    const result = await httpClient.get(`/liquors/${liquorId}`);
     return result.data;
   } catch (err) {
     window.alert('오류가 발생했습니다. 다시 시도해주세요.');

--- a/src/features/CatalogDetail/api/register.api.ts
+++ b/src/features/CatalogDetail/api/register.api.ts
@@ -1,4 +1,4 @@
-import { authInstance } from '@/api/instance';
+import { httpClient } from '@/api/http';
 
 export const register = async ({
   liquorId,
@@ -9,9 +9,9 @@ export const register = async ({
 }) => {
   let result;
   if (liked) {
-    result = await authInstance.delete(`/liquors/${liquorId}/likes`);
+    result = await httpClient.delete(`/liquors/${liquorId}/likes`);
   } else {
-    result = await authInstance.post(`/liquors/${liquorId}/likes`);
+    result = await httpClient.post(`/liquors/${liquorId}/likes`);
   }
   return result;
 };

--- a/src/features/FindPassword/api/findPassword.api.ts
+++ b/src/features/FindPassword/api/findPassword.api.ts
@@ -1,17 +1,17 @@
-import { baseInstance } from '@/api/instance';
+import { httpClient } from '@/api/http';
 
 export const requestResetPassword = async (
   companyNumber: string,
   contact: string
 ) => {
-  await baseInstance.post('/users/password-reset', {
+  await httpClient.post('/users/password-reset', {
     companyNumber,
     contact,
   });
 };
 
 export const resetPassword = async (password: string) => {
-  await baseInstance.put('/users/password-reset', {
+  await httpClient.put('/users/password-reset', {
     password,
   });
 };

--- a/src/features/FindPassword/api/findPassword.api.ts
+++ b/src/features/FindPassword/api/findPassword.api.ts
@@ -1,17 +1,15 @@
 import { httpClient } from '@/api/http';
 
-export const requestResetPassword = async (
-  companyNumber: string,
-  contact: string
-) => {
-  await httpClient.post('/users/password-reset', {
-    companyNumber,
-    contact,
-  });
+export const requestResetPassword = async (req: {
+  companyNumber: string;
+  contact: string;
+}) => {
+  await httpClient.post('/users/password-reset', req);
 };
 
-export const resetPassword = async (password: string) => {
-  await httpClient.put('/users/password-reset', {
-    password,
-  });
+export const resetPassword = async (req: {
+  companyNumber: string;
+  password: string;
+}) => {
+  await httpClient.put('/users/password-reset', req);
 };

--- a/src/features/FindPassword/hooks/useFindPassword.ts
+++ b/src/features/FindPassword/hooks/useFindPassword.ts
@@ -12,7 +12,7 @@ export const useFindPassword = (
 
   const { mutate: requestReset } = useMutation({
     mutationFn: (data: { companyNumber: string; contact: string }) =>
-      requestResetPassword(data.companyNumber, data.contact),
+      requestResetPassword(data),
     onSuccess: () => {
       setStep((prev) => prev + 1);
     },
@@ -22,7 +22,8 @@ export const useFindPassword = (
   });
 
   const { mutate: resetPw } = useMutation({
-    mutationFn: (password: string) => resetPassword(password),
+    mutationFn: (data: { companyNumber: string; password: string }) =>
+      resetPassword(data),
     onSuccess: () => {
       navigate(PATH.login);
     },
@@ -38,7 +39,10 @@ export const useFindPassword = (
         contact: data.phone.toString(),
       });
     } else {
-      resetPw(data.password);
+      resetPw({
+        companyNumber: data.companyNumber.toString(),
+        password: data.password,
+      });
     }
   };
 

--- a/src/features/Join/api/signup.api.ts
+++ b/src/features/Join/api/signup.api.ts
@@ -1,15 +1,15 @@
+import { httpClient } from '@/api/http';
 import axios from 'axios';
-import { baseInstance } from '@/api/instance';
 import { BUSINESS_URL } from '@/constants/url';
 import { KSIC, SignupFormType } from '../types/signup';
 import { BUSINESS_TYPE } from '../constants/business';
 
 export const signup = async (userData: Omit<SignupFormType, 'isVerified'>) => {
-  await baseInstance.post('/users/register', userData);
+  await httpClient.post('/users/register', userData);
 };
 
 export const getKSIC = async (): Promise<KSIC[]> => {
-  const response = await baseInstance.get('/sectors');
+  const response = await httpClient.get('/sectors');
   return response.data;
 };
 
@@ -24,7 +24,7 @@ export const verificationBusiness = async (companyNumber: string) => {
 
 export const duplicateBusiness = async (companyNumber: string) => {
   try {
-    await baseInstance.post('/users/company-number/check', {
+    await httpClient.post('/users/company-number/check', {
       companyNumber,
     });
     return false;

--- a/src/features/Login/api/login.api.ts
+++ b/src/features/Login/api/login.api.ts
@@ -1,11 +1,11 @@
-import { baseInstance } from '@/api/instance';
+import { httpClient } from '@/api/http';
 import { AxiosError, AxiosResponse } from 'axios';
 import { LoginForm } from '../types/login';
 import { LoginRes } from '../models/user.model';
 
 export const login = async (loginData: LoginForm) => {
   try {
-    const result: AxiosResponse<LoginRes> = await baseInstance.post(
+    const result: AxiosResponse<LoginRes> = await httpClient.post(
       '/users/login',
       loginData
     );

--- a/src/features/Profile/api/getProfile.ts
+++ b/src/features/Profile/api/getProfile.ts
@@ -1,6 +1,6 @@
-import { authInstance } from '@/api/instance';
+import { httpClient } from '@/api/http';
 
 export const getProfile = async (id: string, type: string) => {
-  const result = await authInstance.get(`/profile/${id}?type=${type}`);
+  const result = await httpClient.get(`/profile/${id}?type=${type}`);
   return result.data;
 };

--- a/src/features/Profile/api/putProfile.ts
+++ b/src/features/Profile/api/putProfile.ts
@@ -1,7 +1,7 @@
-import { authInstance } from '@/api/instance';
+import { httpClient } from '@/api/http';
 import { Profile } from '../model/profile.model';
 
 export const putProfile = async (data: Profile) => {
-  const result = await authInstance.put('/users/profile', data);
+  const result = await httpClient.put('/users/profile', data);
   return result;
 };


### PR DESCRIPTION
## 📌 작업 내용
- axios instance 통일
- 비밀번호 변경 api 요청 수정 (사업자등록번호 추가)

### ✔️ axios instance
2가지 인스턴스로 나누지 않고 하나로 통일하는 방식으로 변경했습니다.

토큰이 만료되어서 401 에러가 발생했을 때 재발급을 처리하는 로직을 interceptor에 추가해두었는데, 로그인 때도 401 에러가 발생하다보니 이걸 별개의 인스턴스로 처리해야 하는 줄 알았어요..!

멘토님께 조언 듣고 나니 interceptor 내에서 로그인 여부를 판단한 뒤에, 로그인이 된 상태라면 토큰 재발급을 처리하면 되는 문제여서 기존 인스턴스에 재발급 로직만 추가하는 방식으로 변경했습니다~!

<br/>

## 📌 구현 결과 (선택)

<br/>

## 📌 기타 사항
- sessionStore에 로그인 여부를 저장할 것인지에 대한 것은 더 고민해보겠습니다

<br/>
