### PR TITLE
[Style/#89]:구매자 관리 페이지 좌측 정보 UI

### DIFF
--- a/src/features/Catalog/components/Main/ProductCard.tsx
+++ b/src/features/Catalog/components/Main/ProductCard.tsx
@@ -23,9 +23,10 @@ interface Props {
   liquorInfo: LiquorInfo;
   onClick?: () => void;
   button?: ButtonProps;
+  size: string;
 }
 
-function ProductCard({ headText, liquorInfo, onClick, button }: Props) {
+function ProductCard({ headText, liquorInfo, onClick, button, size }: Props) {
   const [imageLoaded, setImageLoaded] = useState(false);
 
   useEffect(() => {
@@ -35,7 +36,7 @@ function ProductCard({ headText, liquorInfo, onClick, button }: Props) {
   }, [liquorInfo.img]);
 
   return (
-    <LiquorInfoContainer onClick={onClick}>
+    <LiquorInfoContainer $size={size} onClick={onClick}>
       {headText && <HeadInfo>{headText}</HeadInfo>}
       <ImgContainer>
         {imageLoaded ? (
@@ -74,10 +75,9 @@ const ImgContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 370px;
 `;
 
-const LiquorInfoContainer = styled.li`
+const LiquorInfoContainer = styled.li<{ $size: string }>`
   cursor: pointer;
 
   position: relative;
@@ -87,11 +87,11 @@ const LiquorInfoContainer = styled.li`
   gap: 20px;
 
   width: 100%;
-  max-width: 370px;
+  max-width: ${({ $size }) => $size}px;
 
   img {
     overflow: hidden;
-    height: 370px;
+    height: ${({ $size }) => $size}px;
   }
 `;
 

--- a/src/features/Catalog/components/Main/ProductCard.tsx
+++ b/src/features/Catalog/components/Main/ProductCard.tsx
@@ -14,7 +14,7 @@ interface LiquorInfo {
 interface Props {
   headText?: string;
   liquorInfo: LiquorInfo;
-  onClick: () => void;
+  onClick?: () => void;
 }
 
 function ProductCard({ headText, liquorInfo, onClick }: Props) {
@@ -66,14 +66,12 @@ const ImgContainer = styled.div`
 
 const LiquorInfoContainer = styled.li`
   cursor: pointer;
-
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 20px;
-
   width: 100%;
   max-width: 370px;
-  padding: 20px;
 
   .img {
     overflow: hidden;
@@ -108,7 +106,6 @@ const spin = keyframes`
 `;
 
 const SpinnerBox = styled.div`
-  position: relative;
   height: 370px;
 `;
 
@@ -117,10 +114,8 @@ const Spinner = styled.div`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-
   width: 40px;
   height: 40px;
-
   border: 4px solid ${({ theme }) => theme.color.neutral[200]};
   border-top: 4px solid ${({ theme }) => theme.color.primary[500]};
   border-radius: 50%;

--- a/src/features/Catalog/components/Main/ProductCard.tsx
+++ b/src/features/Catalog/components/Main/ProductCard.tsx
@@ -79,18 +79,18 @@ const ImgContainer = styled.div`
 
 const LiquorInfoContainer = styled.li`
   cursor: pointer;
+
   position: relative;
+
   display: flex;
   flex-direction: column;
   gap: 20px;
+
   width: 100%;
   max-width: 370px;
 
-  .img {
-    overflow: hidden;
-  }
-
   img {
+    overflow: hidden;
     height: 370px;
   }
 `;
@@ -127,8 +127,10 @@ const Spinner = styled.div`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+
   width: 40px;
   height: 40px;
+
   border: 4px solid ${({ theme }) => theme.color.neutral[200]};
   border-top: 4px solid ${({ theme }) => theme.color.primary[500]};
   border-radius: 50%;

--- a/src/features/Catalog/components/Main/ProductCard.tsx
+++ b/src/features/Catalog/components/Main/ProductCard.tsx
@@ -1,3 +1,4 @@
+import Button from '@/components/Button/Button';
 import HeadInfo from '@/features/Main/components/common/HeadInfo';
 import { Badge } from '@/styles/components/Badge';
 
@@ -11,13 +12,20 @@ interface LiquorInfo {
   description: string;
 }
 
+export interface ButtonProps {
+  label: string;
+  $style: 'solid' | 'outlined';
+  $theme: 'primary' | 'neutral';
+}
+
 interface Props {
   headText?: string;
   liquorInfo: LiquorInfo;
   onClick?: () => void;
+  button?: ButtonProps;
 }
 
-function ProductCard({ headText, liquorInfo, onClick }: Props) {
+function ProductCard({ headText, liquorInfo, onClick, button }: Props) {
   const [imageLoaded, setImageLoaded] = useState(false);
 
   useEffect(() => {
@@ -48,6 +56,11 @@ function ProductCard({ headText, liquorInfo, onClick }: Props) {
         <Title>{liquorInfo.name}</Title>
         <LiquorDescription>{liquorInfo.description}</LiquorDescription>
       </LiquorInfo>
+      {button && (
+        <Button $size='sm' $width='full' {...button}>
+          {button.label}
+        </Button>
+      )}
     </LiquorInfoContainer>
   );
 }

--- a/src/features/Catalog/components/Main/ProductGrid.tsx
+++ b/src/features/Catalog/components/Main/ProductGrid.tsx
@@ -20,6 +20,7 @@ function ProductGrid() {
                   key={item.id}
                   liquorInfo={item}
                   onClick={() => navigate(`/catalog/${item.id}`)}
+                  size='370'
                 />
               );
             })}

--- a/src/features/LiquorDetail/components/Fallback.tsx
+++ b/src/features/LiquorDetail/components/Fallback.tsx
@@ -13,12 +13,12 @@ function Fallback({ error }: FallbackProps) {
 export default Fallback;
 
 const EmptyReview = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
   width: 100%;
   height: 500px;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
 
   color: ${({ theme }) => theme.color.neutral[600]};
   ${({ theme }) => theme.typo.body.semi_bold[16]}

--- a/src/features/LiquorDetail/components/ReviewBox/ReviewListItem.tsx
+++ b/src/features/LiquorDetail/components/ReviewBox/ReviewListItem.tsx
@@ -46,9 +46,9 @@ const Container = styled.div`
   }
 
   .review {
-    white-space: pre-wrap;
     color: ${({ theme }) => theme.color.neutral[400]};
-    ${({ theme }) => theme.typo.body.medium[14]}
+    ${({ theme }) => theme.typo.body.medium[14]};
+    white-space: pre-wrap;
   }
 `;
 

--- a/src/features/Management/components/BuyerDetail/BuyDetail.tsx
+++ b/src/features/Management/components/BuyerDetail/BuyDetail.tsx
@@ -1,15 +1,17 @@
+import { Suspense } from 'react';
 import Button from '@/components/Button/Button';
 import PATH from '@/constants/path';
 import { useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
 import BuyerTable from './BuyerTable';
 import { useOrderDetail } from '../../hooks/useOrderDetail';
-import { Suspense } from 'react';
+
 function BuyDetail() {
   const { id: orderId } = useParams();
   const { orderDetail } = useOrderDetail(Number(orderId));
   const navigate = useNavigate();
   return (
-    <>
+    <Container>
       <Suspense fallback={<></>}>
         <BuyerTable orderDetail={orderDetail} />
       </Suspense>
@@ -22,8 +24,12 @@ function BuyDetail() {
       >
         목록으로 돌아가기
       </Button>
-    </>
+    </Container>
   );
 }
 
 export default BuyDetail;
+
+const Container = styled.div`
+  width: 100%;
+`;

--- a/src/features/Management/components/BuyerDetail/BuyerTable.tsx
+++ b/src/features/Management/components/BuyerDetail/BuyerTable.tsx
@@ -61,6 +61,7 @@ export default BuyerTable;
 const Container = styled.div`
   width: 100%;
   margin-bottom: 20px;
+
   table {
     width: 100%;
   }

--- a/src/features/Management/components/BuyerDetail/BuyerTable.tsx
+++ b/src/features/Management/components/BuyerDetail/BuyerTable.tsx
@@ -60,8 +60,7 @@ export default BuyerTable;
 
 const Container = styled.div`
   width: 100%;
-  margin: 20px 0;
-
+  margin-bottom: 20px;
   table {
     width: 100%;
   }

--- a/src/layouts/ManagementLayout.tsx
+++ b/src/layouts/ManagementLayout.tsx
@@ -3,7 +3,7 @@ import { ButtonProps } from '@/features/Catalog/components/Main/ProductCard';
 import MockImage from 'public/assets/images/main/mock-image1 38.svg';
 
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 const liquors = {
@@ -19,56 +19,55 @@ interface Props {
 
 function ManagementLayout({ children }: Props) {
   const location = useLocation();
+  const { id } = useParams();
 
+  let headText: string | undefined = `총 ${1500}병 신청됐습니다`;
   let buttonProps: ButtonProps = {
     label: '확정',
     $style: 'solid',
     $theme: 'primary',
   };
-
-  if (location.pathname === '/management') {
-    if (location.search === '?achievement') {
-      buttonProps = {
-        label: '전체확정',
-        $style: 'outlined',
-        $theme: 'primary',
-      };
-    } else if (location.search === '?shortfall') {
-      buttonProps = {
-        label: '미달성',
-        $style: 'outlined',
-        $theme: 'neutral',
-      };
-    } else if (location.search === '?cancel') {
-      buttonProps = {
-        label: '전체경고',
-        $style: 'solid',
-        $theme: 'primary',
-      };
-    } else {
-      buttonProps = {
-        label: '확정',
-        $style: 'solid',
-        $theme: 'primary',
-      };
-    }
+  if (id) {
+    headText = undefined;
+  }
+  if (location.search === '?achievement') {
+    buttonProps = {
+      label: '전체확정',
+      $style: 'outlined',
+      $theme: 'primary',
+    };
+  } else if (location.search === '?shortfall') {
+    buttonProps = {
+      label: '미달성',
+      $style: 'outlined',
+      $theme: 'neutral',
+    };
+  } else if (location.search === '?cancel') {
+    buttonProps = {
+      label: '전체경고',
+      $style: 'solid',
+      $theme: 'primary',
+    };
+    headText = undefined;
+  } else if (id) {
+    headText = undefined;
   }
 
   return (
-    <Constainer>
+    <Container>
       <ProductCard
         liquorInfo={liquors}
-        headText='총 1500병 신청됐습니다'
+        headText={headText}
         button={buttonProps}
       />
       {children}
-    </Constainer>
+    </Container>
   );
 }
 
 export default ManagementLayout;
 
-const Constainer = styled.div`
+const Container = styled.div`
   display: flex;
   gap: 40px;
 `;

--- a/src/layouts/ManagementLayout.tsx
+++ b/src/layouts/ManagementLayout.tsx
@@ -49,8 +49,6 @@ function ManagementLayout({ children }: Props) {
       $theme: 'primary',
     };
     headText = undefined;
-  } else if (id) {
-    headText = undefined;
   }
 
   return (
@@ -59,6 +57,7 @@ function ManagementLayout({ children }: Props) {
         liquorInfo={liquors}
         headText={headText}
         button={buttonProps}
+        size='264'
       />
       {children}
     </Container>

--- a/src/layouts/ManagementLayout.tsx
+++ b/src/layouts/ManagementLayout.tsx
@@ -27,22 +27,27 @@ function ManagementLayout({ children }: Props) {
     $style: 'solid',
     $theme: 'primary',
   };
+
+const src =location.search;
+
+  
   if (id) {
     headText = undefined;
   }
-  if (location.search === '?achievement') {
+  
+  if (src === '?achievement') {
     buttonProps = {
       label: '전체확정',
       $style: 'outlined',
       $theme: 'primary',
     };
-  } else if (location.search === '?shortfall') {
+  } else if (src === '?shortfall') {
     buttonProps = {
       label: '미달성',
       $style: 'outlined',
       $theme: 'neutral',
     };
-  } else if (location.search === '?cancel') {
+  } else if (src === '?cancel') {
     buttonProps = {
       label: '전체경고',
       $style: 'solid',

--- a/src/layouts/ManagementLayout.tsx
+++ b/src/layouts/ManagementLayout.tsx
@@ -1,7 +1,9 @@
 import { ProductCard } from '@/features/Catalog';
+import { ButtonProps } from '@/features/Catalog/components/Main/ProductCard';
 import MockImage from 'public/assets/images/main/mock-image1 38.svg';
 
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
 const liquors = {
@@ -16,9 +18,49 @@ interface Props {
 }
 
 function ManagementLayout({ children }: Props) {
+  const location = useLocation();
+
+  let buttonProps: ButtonProps = {
+    label: '확정',
+    $style: 'solid',
+    $theme: 'primary',
+  };
+
+  if (location.pathname === '/management') {
+    if (location.search === '?achievement') {
+      buttonProps = {
+        label: '전체확정',
+        $style: 'outlined',
+        $theme: 'primary',
+      };
+    } else if (location.search === '?shortfall') {
+      buttonProps = {
+        label: '미달성',
+        $style: 'outlined',
+        $theme: 'neutral',
+      };
+    } else if (location.search === '?cancel') {
+      buttonProps = {
+        label: '전체경고',
+        $style: 'solid',
+        $theme: 'primary',
+      };
+    } else {
+      buttonProps = {
+        label: '확정',
+        $style: 'solid',
+        $theme: 'primary',
+      };
+    }
+  }
+
   return (
     <Constainer>
-      <ProductCard liquorInfo={liquors} headText='총 1500병 신청됐습니다' />
+      <ProductCard
+        liquorInfo={liquors}
+        headText='총 1500병 신청됐습니다'
+        button={buttonProps}
+      />
       {children}
     </Constainer>
   );

--- a/src/layouts/ManagementLayout.tsx
+++ b/src/layouts/ManagementLayout.tsx
@@ -1,0 +1,32 @@
+import { ProductCard } from '@/features/Catalog';
+import MockImage from 'public/assets/images/main/mock-image1 38.svg';
+
+import React from 'react';
+import styled from 'styled-components';
+
+const liquors = {
+  img: MockImage,
+  categoryName: '마감',
+  name: '홉미드',
+  description: '고세종고세종고세종고세종고세종',
+};
+
+interface Props {
+  children: React.ReactNode;
+}
+
+function ManagementLayout({ children }: Props) {
+  return (
+    <Constainer>
+      <ProductCard liquorInfo={liquors} headText='총 1500병 신청됐습니다' />
+      {children}
+    </Constainer>
+  );
+}
+
+export default ManagementLayout;
+
+const Constainer = styled.div`
+  display: flex;
+  gap: 40px;
+`;

--- a/src/pages/BuyerDetailPage.tsx
+++ b/src/pages/BuyerDetailPage.tsx
@@ -1,9 +1,12 @@
 import BuyDetail from '@/features/Management/components/BuyerDetail/BuyDetail';
+import ManagementLayout from '@/layouts/ManagementLayout';
 
 function ManagementPage() {
   return (
     <div>
-      <BuyDetail />
+      <ManagementLayout>
+        <BuyDetail />
+      </ManagementLayout>
     </div>
   );
 }


### PR DESCRIPTION
## 📌 작업 내용

- 구매자 관리 페이지 좌측 정보 UI
- 페이지별 headerInfo 추가
- ProductCard size 속성 추가
- ManagementLayout 
```jsx
function ManagementPage() {
  return (
    <div>
      <ManagementLayout>
        <BuyDetail />
      </ManagementLayout>
    </div>
  );
}
```
```jsx
function ManagementLayout({ children }: Props) {
  const location = useLocation();
  const { id } = useParams();

  let headText: string | undefined = `총 ${1500}병 신청됐습니다`;
  let buttonProps: ButtonProps = {
    label: '확정',
    $style: 'solid',
    $theme: 'primary',
  };
  if (id) {
    headText = undefined;
  }
  if (location.search === '?achievement') {
    buttonProps = {
      label: '전체확정',
      $style: 'outlined',
      $theme: 'primary',
    };
  } else if (location.search === '?shortfall') {
    buttonProps = {
      label: '미달성',
      $style: 'outlined',
      $theme: 'neutral',
    };
  } else if (location.search === '?cancel') {
    buttonProps = {
      label: '전체경고',
      $style: 'solid',
      $theme: 'primary',
    };
    headText = undefined;
  } 

  return (
    <Container>
      <ProductCard
        liquorInfo={liquors}
        headText={headText}
        button={buttonProps}
      />
      {children}
    </Container>
  );
}

export default ManagementLayout;
```
<br/>

## 📌 구현 결과 (선택)
![image](https://github.com/user-attachments/assets/81782d29-ec13-44aa-a526-ee175f7b6a52)
<br/>

## 📌 기타 사항

- router 페이지에서 감싸지않고 page내부에서 감쌌는데 검색창을 포함해서 layout을 짜고 때문에 그냥 router페이지에서 감싸는 게 맞는 거 같단 생각이 듭니다.
- 그리고 탭별, 구매자 상세보기에서 달라지는 버튼 스타일을 저런식으로 코드를 짜는 게 너무 지저분해서 맞는지 의문이 듭니다.

<br/>
