### PR TITLE
[Fix/#144]: 카탈로그 헤더 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "date-fns": "^3.6.0",
         "dayjs": "^1.11.13",
         "eslint-import-resolver-typescript": "^3.6.1",
+        "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-datepicker": "^7.3.0",
         "react-daum-postcode": "^3.1.3",
@@ -10501,8 +10502,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "date-fns": "^3.6.0",
     "dayjs": "^1.11.13",
     "eslint-import-resolver-typescript": "^3.6.1",
+    "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-datepicker": "^7.3.0",
     "react-daum-postcode": "^3.1.3",

--- a/src/features/Catalog/components/Header/CatalogHeader.tsx
+++ b/src/features/Catalog/components/Header/CatalogHeader.tsx
@@ -1,11 +1,14 @@
 import PATH from '@/constants/path';
+import { useScroll } from '@/hooks/gesture/useScroll';
 import Search from '@/components/Header/Search';
 import styled from 'styled-components';
 import Category from './Category';
 
 function CatalogHeader() {
+  const { isHided } = useScroll();
+
   return (
-    <Container>
+    <Container $isHided={isHided}>
       <Title>TRADITIONAL LIQUOR SPACE</Title>
       <div className='classification'>
         <Category />
@@ -20,7 +23,7 @@ function CatalogHeader() {
 
 export default CatalogHeader;
 
-const Container = styled.div`
+const Container = styled.div<{ $isHided: boolean }>`
   position: sticky;
   z-index: 90;
   top: 75px;
@@ -35,9 +38,9 @@ const Container = styled.div`
   backdrop-filter: blur(10px);
   border-bottom: 1px solid ${({ theme }) => theme.color.neutral[400]};
 
-  transition:
-    transform 0.3s ease-in-out,
-    opacity 0.3s ease-in-out;
+  transition: all 0.3s ease-in-out;
+  opacity: ${({ $isHided }) => ($isHided ? 0 : 1)};
+  transform: ${({ $isHided }) => ($isHided ? 'translateY(-100%)' : 'none')};
 
   .classification {
     display: flex;

--- a/src/hooks/gesture/useScroll.ts
+++ b/src/hooks/gesture/useScroll.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { throttle } from 'lodash';
+
+export const useScroll = () => {
+  const [isHided, setIsHided] = useState(false);
+  const [lastScrollY, setLastScrollY] = useState(0);
+
+  const lastScrollYRef = useRef(lastScrollY);
+  lastScrollYRef.current = lastScrollY;
+
+  const handleScroll = useCallback(
+    throttle(() => {
+      const currentScrollY = window.scrollY;
+      if (currentScrollY > lastScrollYRef.current) {
+        setIsHided(true);
+      } else {
+        setIsHided(false);
+      }
+      setLastScrollY(currentScrollY);
+    }, 200),
+    []
+  );
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [handleScroll]);
+
+  return { isHided };
+};


### PR DESCRIPTION
## 📌 작업 내용
> 카탈로그 헤더 수정

scroll 이벤트를 걸어서 y 좌표가 이전보다 커진 경우 헤더를 사라지게 합니다. (throttling 적용 O)
`isHided`를 이용해서 컴포넌트를 잠깐 숨겼어요!

<br/>

## 📌 구현 결과 (선택)
![화면 기록 2024-08-28 오후 9 43 25](https://github.com/user-attachments/assets/b2b2bc4b-b31e-4683-8b86-eabb0d51d1ca)

<br/>

## 📌 기타 사항

리뷰어가 특별히 봐주었으면 하는 부분이나 주의사항, 알림사항 등이 있다면
작성해주세요.

<br/>
